### PR TITLE
Vault with multiple mount_points, roles and policies

### DIFF
--- a/stakewise_cli/commands/sync_vault.py
+++ b/stakewise_cli/commands/sync_vault.py
@@ -61,6 +61,7 @@ def validate_operator_address(ctx, param, value):
     callback=validate_operator_address,
 )
 def sync_vault(network: str, operator: ChecksumAddress) -> None:
+    global VAULT_VALIDATORS_MOUNT_POINT
     while True:
         try:
             vault_client = get_vault_client()
@@ -98,6 +99,14 @@ def sync_vault(network: str, operator: ChecksumAddress) -> None:
             fg="red",
         )
 
+    namespace = click.prompt(
+        "Enter the validators kubernetes namespace",
+        default="validators",
+        type=click.STRING,
+    )
+    if VAULT_VALIDATORS_MOUNT_POINT == "":
+        VAULT_VALIDATORS_MOUNT_POINT = namespace
+
     vault_client.secrets.kv.default_kv_version = 1
     try:
         vault_client.sys.enable_secrets_engine(
@@ -126,11 +135,6 @@ def sync_vault(network: str, operator: ChecksumAddress) -> None:
             "Error: failed to connect to the Kubernetes API host", bold=True, fg="red"
         )
 
-    namespace = click.prompt(
-        "Enter the validators kubernetes namespace",
-        default="validators",
-        type=click.STRING,
-    )
     mnemonic = click.prompt(
         'Enter your mnemonic separated by spaces (" ")',
         value_proc=validate_mnemonic,

--- a/stakewise_cli/settings.py
+++ b/stakewise_cli/settings.py
@@ -19,7 +19,7 @@ IPFS_PINATA_SECRET_KEY = config(
 )
 
 VAULT_VALIDATORS_MOUNT_POINT = config(
-    "VAULT_VALIDATORS_MOUNT_POINT", default="validators"
+    "VAULT_VALIDATORS_MOUNT_POINT", default=""
 )
 
 IS_LEGACY = config("IS_LEGACY", default=False, cast=bool)


### PR DESCRIPTION
Hi team, 

Based on https://github.com/stakewise/cli/issues/38 ... sync-vault will create policies and roles with the name `{namespace}-{validator_name}`. The option to define a specific VAULT_VALIDATORS_MOUNT_POINT is still available but, if it is not defined, it will use namespace as the validator mount point.